### PR TITLE
July patches

### DIFF
--- a/docassemble/AppearanceEfile/data/questions/appearance.yml
+++ b/docassemble/AppearanceEfile/data/questions/appearance.yml
@@ -36,7 +36,7 @@ code: |
   is_initial_filing = False
 ---
 objects:
-  - case_search: EFCaseSearch.using(court_id=court_id)
+  - case_search: EFCaseSearch.using(court_id=court_id, do_what_choice="docket_lookup")
 ---
 code: |
   target_case = case_search

--- a/docassemble/AppearanceEfile/data/questions/appearance.yml
+++ b/docassemble/AppearanceEfile/data/questions/appearance.yml
@@ -252,6 +252,8 @@ subquestion: |
   * Probate, or a case involving a will or an estate
   * Juvenile abuse and neglect
   * Criminal (misdemeanor or felony)
+
+  Contact your local circuit clerk, or you can text or call [**IllinoisCourtHelp**](https://ilcourthelp.gov) at (833) 411-1121 for assistance.
 ---
 id: kickout_self_reported_case_type
 event: kickout_self_reported_case_type

--- a/docassemble/AppearanceEfile/data/questions/efile_ports.yml
+++ b/docassemble/AppearanceEfile/data/questions/efile_ports.yml
@@ -72,7 +72,7 @@ subquestion: |
 continue button field: warning_no_appearance_type
 ---
 code: |
-  if court_id == 'tazewell' or court_id == 'kane':
+  if court_id == 'tazewell' or court_id == 'kane' or court_id == 'stephenson':
     if trial_with == "judge_and_6_jury":
       if efile_case_category == "117503": # small claims
         default_list = [None]
@@ -94,7 +94,7 @@ code: |
           "Jury Demand"
         ]]
       else:
-        # TODO(brycew): Can't actually have jury demand in tazewell or kane?
+        # TODO(brycew): Can't actually have jury demand in tazewell/kane/stephenson?
         default_list = []
         filter_list = []
     elif trial_with == "judge_and_12_jury":
@@ -137,7 +137,7 @@ code: |
 ---
 code: |
   if trial_with == "judge_and_6_jury" or trial_with == "judge_and_12_jury":
-    if court_id != "tazewell" and court_id != "kane":
+    if court_id != "tazewell" and court_id != "kane" and court_id != "stephenson":
       illinois_jury_demand_bundle.enabled = True
     else:
       illinois_jury_demand_bundle.enabled = False

--- a/docassemble/AppearanceEfile/data/questions/efile_ports.yml
+++ b/docassemble/AppearanceEfile/data/questions/efile_ports.yml
@@ -73,8 +73,9 @@ continue button field: warning_no_appearance_type
 ---
 code: |
   if court_id == 'tazewell' or court_id == 'kane' or court_id == 'stephenson':
+    efile_case_category_name = case_category_map.get(efile_case_category, {}).get('name', '').lower().strip()
     if trial_with == "judge_and_6_jury":
-      if efile_case_category == "117503": # small claims
+      if efile_case_category_name == "small claims" or efile_case_category == "117503":
         default_list = [None]
         filter_list = [[
           CodeType("20774"),
@@ -84,7 +85,7 @@ code: |
           "Jury Demand"
         ]]
       # if not probate or guardianship
-      elif efile_case_category != "7420" and efile_case_category != "200545":
+      elif efile_case_category_name != "probate" and efile_case_category_name != "guardianship":
         default_list = [None]
         filter_list = [[
           CodeType("124679"),
@@ -98,17 +99,18 @@ code: |
         default_list = []
         filter_list = []
     elif trial_with == "judge_and_12_jury":
-      if efile_case_category == "117503":
+      if efile_case_category_name == "small claims" or efile_case_category_name == "117503":
         default_list = [None]
         filter_list = [[
           CodeType("20773"),
           "SC - Jury Demand - 12 Person",
+          "SC - Jury Demand - 6 Person (12 Person Jury - where 6 person paid by other party)",
           ["SC", "Jury Demand", "12 Person"],
           ["Jury Demand", "12 Person"],
           "Jury Demand"
         ]]
       # if not probate or guardianship
-      elif efile_case_category != "7420" and efile_case_category != "200545":
+      elif efile_case_category_name != "probate" and efile_case_category_name != "guardianship":
         default_list = [None]
         filter_list = [[
           CodeType("124678"),

--- a/docassemble/AppearanceEfile/data/sources/interviews_run.feature
+++ b/docassemble/AppearanceEfile/data/sources/interviews_run.feature
@@ -21,6 +21,7 @@ Some good stage cases to test with:
 * Lake: 78D00000056
 * DuPage: Mary Smith: 2020D000033
   * shouldn't see is_unused_party error
+* Stephenson: 2018SC241 for SC, John Brown
 
 
 @appearance @start @fast @a0
@@ -78,6 +79,7 @@ Scenario: appearance.yml attempting but failing e-filing
   And I set the variable "my_username" to secret "TYLER_EMAIL"
   And I set the variable "my_password" to secret "TYLER_PASSWORD"
   And I tap to continue
+  And I tap to continue
   And I set the variable "case_search.docket_number_from_user" to "BBBBBBB"
   And I tap to continue
   And I wait 30 seconds
@@ -127,10 +129,10 @@ Scenario: appearance.yml with e-filing, search by party name
   And I set the variable "my_username" to secret "TYLER_EMAIL"
   And I set the variable "my_password" to secret "TYLER_PASSWORD"
   And I tap to continue
+  And I tap to continue
   And I set the variable "case_search.docket_number_from_user" to "2018SC241"
   And I tap to continue
   And I wait 50 seconds
-  And I set the variable "x.case_choice" to "case_search.found_cases[0]"
   And I tap to continue
   And I get to the question id "get-docs-screen" with this data:
     | var | value | trigger |

--- a/docassemble/AppearanceEfile/data/sources/interviews_run.feature
+++ b/docassemble/AppearanceEfile/data/sources/interviews_run.feature
@@ -80,7 +80,7 @@ Scenario: appearance.yml attempting but failing e-filing
   And I set the variable "my_password" to secret "TYLER_PASSWORD"
   And I tap to continue
   And I tap to continue
-  And I set the variable "case_search.docket_number_from_user" to "BBBBBBB"
+  And I set the variable "x.docket_number_from_user" to "BBBBBBB"
   And I tap to continue
   And I wait 30 seconds
   And I tap to continue
@@ -130,7 +130,7 @@ Scenario: appearance.yml with e-filing, search by party name
   And I set the variable "my_password" to secret "TYLER_PASSWORD"
   And I tap to continue
   And I tap to continue
-  And I set the variable "case_search.docket_number_from_user" to "2018SC241"
+  And I set the variable "x.docket_number_from_user" to "2018SC241"
   And I tap to continue
   And I wait 50 seconds
   And I tap to continue

--- a/docassemble/AppearanceEfile/data/sources/interviews_run.feature
+++ b/docassemble/AppearanceEfile/data/sources/interviews_run.feature
@@ -77,12 +77,7 @@ Scenario: appearance.yml attempting but failing e-filing
     | user_wants_efile | True | |
   And I set the variable "my_username" to secret "TYLER_EMAIL"
   And I set the variable "my_password" to secret "TYLER_PASSWORD"
-  And I get to the question id "party name" with this data:
-    | var | value | trigger |
-    | x.do_what_choice | party_search | case_search.do_what_choice |
-  And I set the variable "case_search.somebody.person_type" to "ALIndividual"
-  And I set the variable "case_search.somebody.name.first" to "BBBBBBBB"
-  And I set the variable "case_search.somebody.name.last" to "BBBBBACHR"
+  And I set the variable "case_search.docket_number_from_user" to "BBBBBBB"
   And I tap to continue
   And I wait 30 seconds
   And I tap to continue
@@ -130,12 +125,7 @@ Scenario: appearance.yml with e-filing, search by party name
     | user_wants_efile | True | |
   And I set the variable "my_username" to secret "TYLER_EMAIL"
   And I set the variable "my_password" to secret "TYLER_PASSWORD"
-  And I get to the question id "party name" with this data:
-    | var | value | trigger |
-    | x.do_what_choice | party_search | case_search.do_what_choice |
-  And I set the variable "case_search.somebody.person_type" to "ALIndividual"
-  And I set the variable "case_search.somebody.name.first" to "John"
-  And I set the variable "case_search.somebody.name.last" to "Brown"
+  And I set the variable "case_search.docket_number_from_user" to "2018SC241"
   And I tap to continue
   And I wait 50 seconds
   And I set the variable "x.case_choice" to "case_search.found_cases[0]"

--- a/docassemble/AppearanceEfile/data/sources/interviews_run.feature
+++ b/docassemble/AppearanceEfile/data/sources/interviews_run.feature
@@ -77,6 +77,7 @@ Scenario: appearance.yml attempting but failing e-filing
     | user_wants_efile | True | |
   And I set the variable "my_username" to secret "TYLER_EMAIL"
   And I set the variable "my_password" to secret "TYLER_PASSWORD"
+  And I tap to continue
   And I set the variable "case_search.docket_number_from_user" to "BBBBBBB"
   And I tap to continue
   And I wait 30 seconds
@@ -125,6 +126,7 @@ Scenario: appearance.yml with e-filing, search by party name
     | user_wants_efile | True | |
   And I set the variable "my_username" to secret "TYLER_EMAIL"
   And I set the variable "my_password" to secret "TYLER_PASSWORD"
+  And I tap to continue
   And I set the variable "case_search.docket_number_from_user" to "2018SC241"
   And I tap to continue
   And I wait 50 seconds


### PR DESCRIPTION
* Added a court help phone number to the kickout case type
* Added Stephenson to the courts that use optional service for jury demands, with Kane and Tazewell
* Automatically select case number search for case search, since we can't use name search anymore

Tested 1 and 3, am about to test 2 and then will merge. The case number question does look slightly out of place now, but I'll edit it in the EFSPIntegration package.