### PR TITLE
Bold dropdown subject on case search

### DIFF
--- a/docassemble/AppearanceEfile/data/questions/efile_ports.yml
+++ b/docassemble/AppearanceEfile/data/questions/efile_ports.yml
@@ -435,10 +435,9 @@ continue button field: x.warn_no_results
 generic object: EFCaseSearch
 template: x.not_actually_case
 subject: |
-  This isn't my case!
+  **This isn't my case!**
 content: |
   If we found the wrong case, you can press the **${ all_variables(special="titles").get("back button label", "back") }** button to go back and find a different case
----
 ---
 # Won't do non-indexed filings, so forcing it out
 generic object: EFCaseSearch


### PR DESCRIPTION
Matches ILAO's style in other interviews (see https://github.com/IllinoisLegalAidOnline/docassemble-AppearanceEfile/blob/8e7662128c3d2766a5b0a89353db6cad8d486283/docassemble/AppearanceEfile/data/questions/appearance.yml#L428 for an example).

Additionally removed an extra, unneeded YAML questions boundary (`---`).